### PR TITLE
Fix command-line instruction $npm run-script dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For setting up & starting the project locally, use:
 $ git clone https://github.com/zippyui/react-input-field
 $ cd react-input-field
 $ npm install
-$ npm run-script dev
+$ npm run dev
 ```
 
 Now navigate to [localhost:9090](http://localhost:9090/)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For setting up & starting the project locally, use:
 $ git clone https://github.com/zippyui/react-input-field
 $ cd react-input-field
 $ npm install
-$ npm dev
+$ npm run-script dev
 ```
 
 Now navigate to [localhost:9090](http://localhost:9090/)


### PR DESCRIPTION
When I tried to follow your command-line instruction, the command `$npm dev` didn't work for me.

But this command `$npm run-script dev` did work!!

I'm a total NodeJS newbie, so forgive me if I've overlooked something obvious!!  :-)